### PR TITLE
Canvas as an attribute of SDL2Window

### DIFF
--- a/include/sdl2canvas.h
+++ b/include/sdl2canvas.h
@@ -11,7 +11,7 @@ namespace ijengine {
         SDL2Canvas(SDL_Renderer *renderer);
         void draw(const Texture *texture, int x, int y);
 
-        SDL_Renderer * renderer() const { return m_renderer; }
+        SDL_Renderer * renderer() const;
         void update();
     private:
         SDL_Renderer *m_renderer;

--- a/include/sdl2window.h
+++ b/include/sdl2window.h
@@ -3,6 +3,7 @@
 
 #include "window.h"
 #include <SDL2/SDL.h>
+#include "canvas.h"
 
 namespace ijengine {
 
@@ -18,6 +19,7 @@ namespace ijengine {
     private:
         SDL_Window *m_window;
         SDL_Renderer *m_renderer;
+        Canvas *m_canvas;
 
         int m_w;
         int m_h;

--- a/src/sdl2canvas.cpp
+++ b/src/sdl2canvas.cpp
@@ -5,28 +5,32 @@
 
 namespace ijengine {
 
-SDL2Canvas::SDL2Canvas(SDL_Renderer *renderer)
-    : m_renderer(renderer)
-{
-}
+    SDL2Canvas::SDL2Canvas(SDL_Renderer *renderer)
+        : m_renderer(renderer)
+    {
+    }
 
-void
-SDL2Canvas::draw(const Texture *texture, int x, int y)
-{
-    const SDL2Texture *text = dynamic_cast<const SDL2Texture *>(texture);
+    void
+    SDL2Canvas::draw(const Texture *texture, int x, int y)
+    {
+        const SDL2Texture *text = dynamic_cast<const SDL2Texture *>(texture);
 
-    SDL_SetRenderDrawColor(m_renderer, 255, 255, 255, 0);
-    SDL_RenderClear(m_renderer);
+        SDL_SetRenderDrawColor(m_renderer, 255, 255, 255, 0);
+        SDL_RenderClear(m_renderer);
 
-    SDL_Rect rect { x, y, text->w(), text->h() };
-    SDL_RenderCopy(m_renderer, text->texture(), nullptr, nullptr);
-    SDL_RenderPresent(m_renderer);
-}
+        SDL_Rect rect { x, y, text->w(), text->h() };
+        SDL_RenderCopy(m_renderer, text->texture(), nullptr, &rect);
+        SDL_RenderPresent(m_renderer);
+    }
 
-void
-SDL2Canvas::update()
-{
-    SDL_RenderPresent(m_renderer);
-}
+    SDL_Renderer *
+    SDL2Canvas::renderer() const {
+        return m_renderer;
+    }
 
+    void
+    SDL2Canvas::update()
+    {
+        SDL_RenderPresent(m_renderer);
+    }
 }

--- a/src/sdl2window.cpp
+++ b/src/sdl2window.cpp
@@ -5,7 +5,7 @@
 namespace ijengine {
 
     SDL2Window::SDL2Window(SDL_Window *new_window, SDL_Renderer *actual_renderer) :
-        m_window(new_window), m_renderer(actual_renderer), m_w(0), m_h(0)
+        m_window(new_window), m_renderer(actual_renderer), m_canvas(new SDL2Canvas(actual_renderer)), m_w(0), m_h(0)
     {
         if (m_window)
         {
@@ -39,6 +39,6 @@ namespace ijengine {
     Canvas *
     SDL2Window::canvas() const
     {
-        return new SDL2Canvas(m_renderer);
+        return m_canvas;
     }
 }


### PR DESCRIPTION
I've committed two changes:

1 - The SDL2Canvas' renderer method was implemented on its interface, i.e. the .h file. I just put it in its respective .cpp.

2 - The SDL2Window had a method (canvas()) to return a pointer to a Canvas object based on a given renderer. Instead, I put an attribute called m_canvas in SDL2Window and, now, the method canvas() just returns it. I don't know if this is optimal or if there was a reason not to have a Canvas' attribute. If so, let me know.