### PR TITLE
Put 'now' and 'last' as parameters in collision interface.

### DIFF
--- a/include/collidable.h
+++ b/include/collidable.h
@@ -22,8 +22,7 @@ namespace ijengine
         virtual const Rectangle& bounding_box() const = 0;
         virtual const list<Rectangle>& hit_boxes() const = 0;
 
-        virtual void on_collision(const Collidable *who,
-            const Rectangle& where) = 0;
+        virtual void on_collision(const Collidable *who, const Rectangle& where, const unsigned now, const unsigned last) = 0;
     };
 }
 

--- a/include/engine.h
+++ b/include/engine.h
@@ -77,7 +77,7 @@ namespace ijengine {
 
         void register_object(Collidable *c);
         void unregister_object(Collidable *c);
-        void do_collisions();
+        void do_collisions(unsigned now, unsigned last);
         void set_collision_mode(Mode mode, Collidable *c = nullptr);
     }
 }

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -334,7 +334,7 @@ namespace ijengine
         }
 
         void
-        do_collisions()
+        do_collisions(unsigned now, unsigned last)
         {
             switch (collisions_mode) {
             case ONE_TO_ALL:
@@ -347,8 +347,8 @@ namespace ijengine
 
                     if (r.area() > 0)
                     {
-                        target->on_collision(obj, r);
-                        obj->on_collision(target, r);
+                        target->on_collision(obj, r, now, last);
+                        obj->on_collision(target, r, now, last);
                     }
                 }
 
@@ -369,8 +369,8 @@ namespace ijengine
 
                         if (r.area() > 0)
                         {
-                            a->on_collision(b, r);
-                            b->on_collision(a, r);
+                            a->on_collision(b, r, now, last);
+                            b->on_collision(a, r, now, last);
                         }
                     }
                 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -51,7 +51,7 @@ namespace ijengine {
 
             audio::play_audio_from_path(current_level->audio());
 
-            physics::do_collisions();
+            physics::do_collisions(now, last);
 
             current_level->draw(canvas, now, last);
             canvas->update();


### PR DESCRIPTION
Having information about 'now' and 'last' parameters in collision methods might be useful for proper adjustment of Game Objects' positions when a collision occurs.